### PR TITLE
Add lexical field gap report with click-to-reveal hints

### DIFF
--- a/.github/workflows/lexical-report.yml
+++ b/.github/workflows/lexical-report.yml
@@ -1,0 +1,40 @@
+name: Lexical field report
+
+# Regenerates docs/index.html (which fields of lully/words.py still need
+# words, per lexical_report.py) whenever the corpus or the report script
+# changes on main, and commits the result back.
+#
+# One-time setup: in the repo's Settings > Pages, set "Source" to
+# "Deploy from a branch", branch "main", folder "/docs".
+
+"on":
+  push:
+    branches: [main]
+    paths:
+      - "lully/words.py"
+      - "lexical_report.py"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Generate report
+        run: python lexical_report.py --words lully/words.py --out docs/index.html
+
+      - name: Commit report if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add docs/index.html
+          git diff --cached --quiet || git commit -m "docs: regenerate lexical field report"
+          git push

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,822 @@
+<title>Lully — champs lexicaux à compléter</title>
+<style>
+  @media (prefers-color-scheme: light) { :root { color-scheme: light; } }
+  @media (prefers-color-scheme: dark) { :root { color-scheme: dark; } }
+
+  :root {
+    --paper: #e7e2d2;
+    --paper-raised: #f4f0e2;
+    --ink: #22291f;
+    --ink-soft: #5a5d4d;
+    --line: #c9c2a4;
+    --bien: #3f6b45;
+    --bien-soft: #dbe6d7;
+    --partiel: #a2793a;
+    --partiel-soft: #ecdfc5;
+    --non: #8c3f33;
+    --non-soft: #ecd8d2;
+    --missing: #8c3f33;
+    --missing-soft: #f3e2dc;
+    --font-display: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, "Times New Roman", serif;
+    --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper: #1b211c; --paper-raised: #232921; --ink: #e9e4d3; --ink-soft: #a9a491;
+      --line: #3c4335; --bien: #7cb583; --bien-soft: #2b3a2c; --partiel: #d3a463;
+      --partiel-soft: #3a3221; --non: #cf7767; --non-soft: #3c2723;
+      --missing: #d98871; --missing-soft: #3a2924;
+    }
+  }
+  :root[data-theme="dark"] {
+    --paper: #1b211c; --paper-raised: #232921; --ink: #e9e4d3; --ink-soft: #a9a491;
+    --line: #3c4335; --bien: #7cb583; --bien-soft: #2b3a2c; --partiel: #d3a463;
+    --partiel-soft: #3a3221; --non: #cf7767; --non-soft: #3c2723;
+    --missing: #d98871; --missing-soft: #3a2924;
+  }
+  :root[data-theme="light"] {
+    --paper: #e7e2d2; --paper-raised: #f4f0e2; --ink: #22291f; --ink-soft: #5a5d4d;
+    --line: #c9c2a4; --bien: #3f6b45; --bien-soft: #dbe6d7; --partiel: #a2793a;
+    --partiel-soft: #ecdfc5; --non: #8c3f33; --non-soft: #ecd8d2;
+    --missing: #8c3f33; --missing-soft: #f3e2dc;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--font-body);
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 880px; margin: 0 auto; padding: 2.25rem 1.25rem 5rem; }
+
+  header.page-head { margin-bottom: 2.25rem; }
+  .eyebrow {
+    font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--ink-soft);
+  }
+  h1 {
+    font-family: var(--font-display); font-weight: 600;
+    font-size: clamp(1.6rem, 5vw, 2.35rem); margin: 0.35rem 0 0.6rem; text-wrap: balance;
+  }
+  .lede { max-width: 62ch; color: var(--ink-soft); font-size: 0.98rem; }
+  .lede b { color: var(--ink); font-weight: 600; }
+
+  .stats { display: flex; gap: 1.5rem; margin-top: 1.15rem; flex-wrap: wrap; }
+  .stat { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+  .stat .n { font-size: 1.3rem; color: var(--ink); }
+  .stat .l {
+    display: block; font-size: 0.68rem; color: var(--ink-soft);
+    letter-spacing: 0.06em; text-transform: uppercase;
+  }
+
+  .priority {
+    margin: 1.5rem 0 0;
+    padding: 0.9rem 1rem;
+    background: var(--missing-soft);
+    border-left: 3px solid var(--missing);
+    border-radius: 0 3px 3px 0;
+  }
+  .priority h2 {
+    font-family: var(--font-display); font-size: 1.05rem; margin: 0 0 0.5rem;
+  }
+  .priority ol { margin: 0; padding-left: 1.2rem; columns: 2; column-gap: 1.5rem; }
+  .priority li { font-size: 0.88rem; margin-bottom: 0.25rem; break-inside: avoid; }
+  .priority a { color: var(--ink); }
+  .prio-pct { font-family: var(--font-mono); font-size: 0.75rem; color: var(--ink-soft); }
+
+  .tree { position: relative; margin-left: 0.6rem; padding-left: 1.6rem; border-left: 3px solid var(--line); margin-top: 2rem; }
+  .tier { position: relative; margin-bottom: 2.75rem; }
+  .tier:last-child { margin-bottom: 0; }
+  .tier-node {
+    position: relative; display: flex; align-items: baseline; gap: 0.6rem;
+    font-family: var(--font-display); font-size: 1.28rem; font-weight: 600;
+    margin: 0 0 1.1rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--line);
+  }
+  .tier-node::before {
+    content: ""; position: absolute; left: -1.98rem; top: 0.55em;
+    width: 1.3rem; height: 3px; background: var(--dot);
+  }
+  .tier-node::after {
+    content: ""; position: absolute; left: -2.35rem; top: 0.35em;
+    width: 0.85rem; height: 0.85rem; border-radius: 50%;
+    background: var(--paper); border: 3px solid var(--dot);
+  }
+  .tier--bien { --dot: var(--bien); }
+  .tier--partiel { --dot: var(--partiel); }
+  .tier--non { --dot: var(--non); }
+  .tier-node .count { font-family: var(--font-mono); font-size: 0.85rem; font-weight: 400; color: var(--ink-soft); }
+
+  .cards { display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 0.85rem; }
+
+  .card {
+    background: var(--paper-raised); border: 1px solid var(--line);
+    border-left: 4px solid var(--dot); border-radius: 3px; padding: 0.85rem 0.95rem 0.95rem;
+    scroll-margin-top: 1rem;
+  }
+  .card-head { display: flex; justify-content: space-between; align-items: baseline; gap: 0.5rem; margin-bottom: 0.55rem; }
+  .card h3 { font-family: var(--font-display); font-size: 1.02rem; font-weight: 600; margin: 0; text-wrap: balance; }
+  .tag {
+    flex: none; font-family: var(--font-mono); font-size: 0.62rem; letter-spacing: 0.05em;
+    text-transform: uppercase; color: var(--ink-soft); border: 1px solid var(--line);
+    border-radius: 2px; padding: 0.1rem 0.35rem; white-space: nowrap;
+  }
+  .gauge {
+    position: relative; height: 0.55rem; background: var(--paper); border: 1px solid var(--line);
+    border-radius: 2px; margin-bottom: 0.75rem; overflow: hidden;
+  }
+  .gauge-fill { position: absolute; inset: 0; width: var(--pct); background: var(--dot); border-radius: 2px 0 0 2px; }
+  .gauge-label {
+    position: absolute; right: 0.35rem; top: -1.2rem; font-family: var(--font-mono);
+    font-size: 0.7rem; font-variant-numeric: tabular-nums; color: var(--ink-soft);
+  }
+  .chips { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+  .chip { font-size: 0.76rem; border-radius: 20px; padding: 0.12rem 0.55rem; }
+  .chip--missing {
+    background: transparent; color: var(--missing); border: 1px dashed var(--missing);
+  }
+  .chip--done { font-style: italic; color: var(--ink-soft); border: 1px solid var(--line); }
+  .chip--present { background: var(--paper); color: var(--ink-soft); border: 1px solid var(--line); }
+  .missing-row { margin-bottom: 0.5rem; }
+  .missing-label, .present-label {
+    display: block; font-family: var(--font-mono); font-size: 0.65rem; letter-spacing: 0.04em;
+    text-transform: uppercase; margin-bottom: 0.3rem;
+  }
+  .missing-label { color: var(--missing); }
+  .present-label { color: var(--ink-soft); }
+  .present-row { margin-top: 0.55rem; padding-top: 0.55rem; border-top: 1px dashed var(--line); }
+  .note { margin: 0.55rem 0 0; font-size: 0.78rem; color: var(--ink-soft); font-style: italic; }
+
+  .reveal-chips:empty { display: none; }
+  .reveal-chips { margin-bottom: 0.4rem; }
+  .reveal-btn {
+    font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.02em;
+    color: var(--missing); background: var(--missing-soft); border: 1px solid var(--missing);
+    border-radius: 20px; padding: 0.28rem 0.7rem; cursor: pointer;
+  }
+  .reveal-btn:hover { filter: brightness(1.08); }
+  .reveal-btn:disabled {
+    cursor: default; color: var(--ink-soft); background: transparent;
+    border-color: var(--line); filter: none;
+  }
+  .chip--revealed { background: var(--missing-soft); color: var(--missing); border: 1px solid var(--missing); }
+  @media (prefers-reduced-motion: no-preference) {
+    .chip--revealed { animation: reveal 0.25s ease-out; }
+    @keyframes reveal {
+      from { opacity: 0; transform: translateY(-2px) scale(0.92); }
+      to { opacity: 1; transform: none; }
+    }
+  }
+
+  footer.legend {
+    margin-top: 3rem; padding-top: 1.25rem; border-top: 1px solid var(--line);
+    font-size: 0.82rem; color: var(--ink-soft); max-width: 62ch;
+  }
+  footer.legend p { margin: 0 0 0.6rem; }
+
+  @media (max-width: 480px) {
+    main { padding: 1.5rem 0.85rem 4rem; }
+    .tree { padding-left: 1.15rem; }
+    .tier-node::before { left: -1.5rem; width: 0.9rem; }
+    .tier-node::after { left: -1.83rem; }
+    .priority ol { columns: 1; }
+  }
+</style>
+
+<main>
+  <header class="page-head">
+    <p class="eyebrow">Lully · rapport de champs lexicaux</p>
+    <h1>Quels mots manquent encore au corpus ?</h1>
+    <p class="lede">
+      Pour chaque champ, une liste de mots-témoins caractéristiques du domaine est vérifiée
+      contre <code>lully/words.py</code>. Essaie de trouver les manquants toi-même — le bouton
+      « Révéler un indice » de chaque carte en sort un à la fois si tu sèches, prêt à copier
+      dans <code>addwords.py</code>. Ce rapport se régénère à chaque commit qui touche le corpus.
+    </p>
+    <div class="stats">
+      <div class="stat"><span class="n">3515</span><span class="l">noms</span></div>
+      <div class="stat"><span class="n">3535</span><span class="l">adjectifs</span></div>
+      <div class="stat"><span class="n">33</span><span class="l">champs suivis</span></div>
+    </div>
+    <div class="priority">
+      <h2>Par où commencer</h2>
+      <ol><li><a href="#numérique-grand-public--ia--réseaux--smartphone">Numérique grand public (IA, réseaux, smartphone)</a> <span class="prio-pct">19&nbsp;%</span></li><li><a href="#parenté-par-adjectif--filiation">Parenté par adjectif (filiation)</a> <span class="prio-pct">25&nbsp;%</span></li><li><a href="#médecine--maux-du-corps">Médecine, maux du corps</a> <span class="prio-pct">40&nbsp;%</span></li><li><a href="#parenté-proche">Parenté proche</a> <span class="prio-pct">41&nbsp;%</span></li><li><a href="#écologie---environnement">Écologie &amp; environnement</a> <span class="prio-pct">42&nbsp;%</span></li><li><a href="#couleurs-nommées">Couleurs nommées</a> <span class="prio-pct">47&nbsp;%</span></li><li><a href="#religion---liturgie">Religion &amp; liturgie</a> <span class="prio-pct">48&nbsp;%</span></li><li><a href="#vocabulaire-logiciel---dev">Vocabulaire logiciel / dev</a> <span class="prio-pct">53&nbsp;%</span></li></ol>
+    </div>
+  </header>
+
+  <div class="tree">
+    <section class="tier tier--bien">
+      <h2 class="tier-node">Bien couverts <span class="count">19 champs</span></h2>
+      <div class="cards">
+        <article class="card" id="états-émotionnels">
+          <div class="card-head">
+            <h3>États émotionnels</h3>
+            <span class="tag">adjectifs</span>
+          </div>
+          <div class="gauge" style="--pct:70%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">70 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (3 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Anxieuse&quot;, &quot;Apaisée&quot;, &quot;Furieuse&quot;]">🔍 Révéler un indice (3 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (7/10)</span><div class="chips"><span class="chip chip--present">Joyeuse</span><span class="chip chip--present">Triste</span><span class="chip chip--present">Sereine</span><span class="chip chip--present">Mélancolique</span><span class="chip chip--present">Exaltée</span><span class="chip chip--present">Radieuse</span><span class="chip chip--present">Morose</span></div></div>
+          
+        </article>
+        <article class="card" id="saveurs">
+          <div class="card-head">
+            <h3>Saveurs</h3>
+            <span class="tag">adjectifs</span>
+          </div>
+          <div class="gauge" style="--pct:75%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">75 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (2 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Fade&quot;, &quot;Insipide&quot;]">🔍 Révéler un indice (2 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (6/8)</span><div class="chips"><span class="chip chip--present">Sucrée</span><span class="chip chip--present">Salée</span><span class="chip chip--present">Amère</span><span class="chip chip--present">Acide</span><span class="chip chip--present">Épicée</span><span class="chip chip--present">Savoureuse</span></div></div>
+          
+        </article>
+        <article class="card" id="finance---économie">
+          <div class="card-head">
+            <h3>Finance &amp; économie</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:79%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">79 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (3 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Spéculation&quot;, &quot;Rentabilité&quot;, &quot;Solvabilité&quot;]">🔍 Révéler un indice (3 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (11/14)</span><div class="chips"><span class="chip chip--present">Banque</span><span class="chip chip--present">Bourse</span><span class="chip chip--present">Capitalisation</span><span class="chip chip--present">Liquidité</span><span class="chip chip--present">Dette</span><span class="chip chip--present">Monnaie</span><span class="chip chip--present">Fortune</span><span class="chip chip--present">Prospérité</span><span class="chip chip--present">Inflation</span><span class="chip chip--present">Récession</span><span class="chip chip--present">Économie</span></div></div>
+          
+        </article>
+        <article class="card" id="textures---matières">
+          <div class="card-head">
+            <h3>Textures &amp; matières</h3>
+            <span class="tag">adjectifs</span>
+          </div>
+          <div class="gauge" style="--pct:80%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">80 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (2 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Lisse&quot;, &quot;Cotonneuse&quot;]">🔍 Révéler un indice (2 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (8/10)</span><div class="chips"><span class="chip chip--present">Rugueuse</span><span class="chip chip--present">Soyeuse</span><span class="chip chip--present">Visqueuse</span><span class="chip chip--present">Granuleuse</span><span class="chip chip--present">Poreuse</span><span class="chip chip--present">Élastique</span><span class="chip chip--present">Collante</span><span class="chip chip--present">Huileuse</span></div></div>
+          
+        </article>
+        <article class="card" id="sciences---techniques-en--ique">
+          <div class="card-head">
+            <h3>Sciences &amp; techniques en -ique</h3>
+            <span class="tag">adjectifs</span>
+          </div>
+          <div class="gauge" style="--pct:80%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">80 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (2 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Génétique&quot;, &quot;Mécanique&quot;]">🔍 Révéler un indice (2 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (8/10)</span><div class="chips"><span class="chip chip--present">Chimique</span><span class="chip chip--present">Biologique</span><span class="chip chip--present">Électrique</span><span class="chip chip--present">Magnétique</span><span class="chip chip--present">Acoustique</span><span class="chip chip--present">Atomique</span><span class="chip chip--present">Numérique</span><span class="chip chip--present">Organique</span></div></div>
+          
+        </article>
+        <article class="card" id="armement---guerre">
+          <div class="card-head">
+            <h3>Armement &amp; guerre</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:82%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">82 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (2 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Baïonnette&quot;, &quot;Garnison&quot;]">🔍 Révéler un indice (2 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (9/11)</span><div class="chips"><span class="chip chip--present">Arquebuse</span><span class="chip chip--present">Cuirasse</span><span class="chip chip--present">Armure</span><span class="chip chip--present">Artillerie</span><span class="chip chip--present">Bataille</span><span class="chip chip--present">Embuscade</span><span class="chip chip--present">Arbalète</span><span class="chip chip--present">Hallebarde</span><span class="chip chip--present">Catapulte</span></div></div>
+          
+        </article>
+        <article class="card" id="musique--danse--instruments">
+          <div class="card-head">
+            <h3>Musique, danse, instruments</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:83%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">83 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (2 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Mandoline&quot;, &quot;Polka&quot;]">🔍 Révéler un indice (2 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (10/12)</span><div class="chips"><span class="chip chip--present">Guitare</span><span class="chip chip--present">Cornemuse</span><span class="chip chip--present">Harpe</span><span class="chip chip--present">Clarinette</span><span class="chip chip--present">Chorale</span><span class="chip chip--present">Gigue</span><span class="chip chip--present">Cymbale</span><span class="chip chip--present">Flûte</span><span class="chip chip--present">Sarabande</span><span class="chip chip--present">Tarentelle</span></div></div>
+          
+        </article>
+        <article class="card" id="métiers---professions-féminisées">
+          <div class="card-head">
+            <h3>Métiers &amp; professions féminisées</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:85%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">85 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (3 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Avocate&quot;, &quot;Conductrice&quot;, &quot;Boulangère&quot;]">🔍 Révéler un indice (3 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (17/20)</span><div class="chips"><span class="chip chip--present">Institutrice</span><span class="chip chip--present">Danseuse</span><span class="chip chip--present">Chercheuse</span><span class="chip chip--present">Journaliste</span><span class="chip chip--present">Pianiste</span><span class="chip chip--present">Bibliothécaire</span><span class="chip chip--present">Infirmière</span><span class="chip chip--present">Architecte</span><span class="chip chip--present">Biographe</span><span class="chip chip--present">Astronome</span><span class="chip chip--present">Actrice</span><span class="chip chip--present">Autrice</span><span class="chip chip--present">Ouvrière</span><span class="chip chip--present">Couturière</span><span class="chip chip--present">Artificière</span><span class="chip chip--present">Chirurgienne</span><span class="chip chip--present">Juriste</span></div></div>
+          
+        </article>
+        <article class="card" id="émotions---états-d-âme">
+          <div class="card-head">
+            <h3>Émotions &amp; états d&#x27;âme</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:85%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">85 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (3 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Mélancolie&quot;, &quot;Envie&quot;, &quot;Exaltation&quot;]">🔍 Révéler un indice (3 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (17/20)</span><div class="chips"><span class="chip chip--present">Joie</span><span class="chip chip--present">Tristesse</span><span class="chip chip--present">Angoisse</span><span class="chip chip--present">Nostalgie</span><span class="chip chip--present">Extase</span><span class="chip chip--present">Frayeur</span><span class="chip chip--present">Colère</span><span class="chip chip--present">Ardeur</span><span class="chip chip--present">Peur</span><span class="chip chip--present">Honte</span><span class="chip chip--present">Fierté</span><span class="chip chip--present">Jalousie</span><span class="chip chip--present">Allégresse</span><span class="chip chip--present">Désolation</span><span class="chip chip--present">Inquiétude</span><span class="chip chip--present">Anxiété</span><span class="chip chip--present">Consternation</span></div></div>
+          
+        </article>
+        <article class="card" id="figures-de-style---rhétorique">
+          <div class="card-head">
+            <h3>Figures de style &amp; rhétorique</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:86%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">86 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (4 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Chiasme&quot;, &quot;Oxymore&quot;, &quot;Zeugme&quot;, &quot;Antiphrase&quot;]">🔍 Révéler un indice (4 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (25/29)</span><div class="chips"><span class="chip chip--present">Anacoluthe</span><span class="chip chip--present">Antanaclase</span><span class="chip chip--present">Antonomase</span><span class="chip chip--present">Asyndète</span><span class="chip chip--present">Litote</span><span class="chip chip--present">Métaphore</span><span class="chip chip--present">Métonymie</span><span class="chip chip--present">Anaphore</span><span class="chip chip--present">Antithèse</span><span class="chip chip--present">Paronomase</span><span class="chip chip--present">Hyperbate</span><span class="chip chip--present">Parembole</span><span class="chip chip--present">Allitération</span><span class="chip chip--present">Anadiplose</span><span class="chip chip--present">Apostrophe</span><span class="chip chip--present">Hypallage</span><span class="chip chip--present">Hyperbole</span><span class="chip chip--present">Allégorie</span><span class="chip chip--present">Synecdoque</span><span class="chip chip--present">Ellipse</span><span class="chip chip--present">Périphrase</span><span class="chip chip--present">Tautologie</span><span class="chip chip--present">Gradation</span><span class="chip chip--present">Comparaison</span><span class="chip chip--present">Personnification</span></div></div>
+          
+        </article>
+        <article class="card" id="sciences-savantes-en--logie----graphie">
+          <div class="card-head">
+            <h3>Sciences savantes en -logie / -graphie</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:86%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">86 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (3 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Psychologie&quot;, &quot;Météorologie&quot;, &quot;Cartographie&quot;]">🔍 Révéler un indice (3 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (18/21)</span><div class="chips"><span class="chip chip--present">Biologie</span><span class="chip chip--present">Astronomie</span><span class="chip chip--present">Anthropologie</span><span class="chip chip--present">Cristallographie</span><span class="chip chip--present">Démographie</span><span class="chip chip--present">Géologie</span><span class="chip chip--present">Sociologie</span><span class="chip chip--present">Chronologie</span><span class="chip chip--present">Bibliographie</span><span class="chip chip--present">Numismatique</span><span class="chip chip--present">Botanique</span><span class="chip chip--present">Zoologie</span><span class="chip chip--present">Criminologie</span><span class="chip chip--present">Climatologie</span><span class="chip chip--present">Ethnologie</span><span class="chip chip--present">Phonologie</span><span class="chip chip--present">Morphologie</span><span class="chip chip--present">Physiologie</span></div></div>
+          
+        </article>
+        <article class="card" id="cuisine---gourmandise">
+          <div class="card-head">
+            <h3>Cuisine &amp; gourmandise</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:91%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">91 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (1 piste)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Omelette&quot;]">🔍 Révéler un indice (1 restant)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (10/11)</span><div class="chips"><span class="chip chip--present">Confiture</span><span class="chip chip--present">Choucroute</span><span class="chip chip--present">Fondue</span><span class="chip chip--present">Marmelade</span><span class="chip chip--present">Charcuterie</span><span class="chip chip--present">Pâtisserie</span><span class="chip chip--present">Brioche</span><span class="chip chip--present">Soupe</span><span class="chip chip--present">Compote</span><span class="chip chip--present">Confiserie</span></div></div>
+          
+        </article>
+        <article class="card" id="relief---paysages-d-eau">
+          <div class="card-head">
+            <h3>Relief &amp; paysages d&#x27;eau</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:91%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">91 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (1 piste)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Presqu&#x27;Île&quot;]">🔍 Révéler un indice (1 restant)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (10/11)</span><div class="chips"><span class="chip chip--present">Montagne</span><span class="chip chip--present">Vallée</span><span class="chip chip--present">Rivière</span><span class="chip chip--present">Falaise</span><span class="chip chip--present">Colline</span><span class="chip chip--present">Plaine</span><span class="chip chip--present">Péninsule</span><span class="chip chip--present">Crique</span><span class="chip chip--present">Lagune</span><span class="chip chip--present">Cascade</span></div></div>
+          
+        </article>
+        <article class="card" id="objets---outils-du-quotidien">
+          <div class="card-head">
+            <h3>Objets &amp; outils du quotidien</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:92%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">92 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (1 piste)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Épingle&quot;]">🔍 Révéler un indice (1 restant)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (11/12)</span><div class="chips"><span class="chip chip--present">Pince</span><span class="chip chip--present">Fourchette</span><span class="chip chip--present">Cuillère</span><span class="chip chip--present">Casserole</span><span class="chip chip--present">Bouilloire</span><span class="chip chip--present">Aiguille</span><span class="chip chip--present">Brosse</span><span class="chip chip--present">Éponge</span><span class="chip chip--present">Bassine</span><span class="chip chip--present">Louche</span><span class="chip chip--present">Lime</span></div></div>
+          
+        </article>
+        <article class="card" id="temps---durée">
+          <div class="card-head">
+            <h3>Temps &amp; durée</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:92%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">92 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (1 piste)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Ère&quot;]">🔍 Révéler un indice (1 restant)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (11/12)</span><div class="chips"><span class="chip chip--present">Décennie</span><span class="chip chip--present">Journée</span><span class="chip chip--present">Matinée</span><span class="chip chip--present">Soirée</span><span class="chip chip--present">Éternité</span><span class="chip chip--present">Semaine</span><span class="chip chip--present">Année</span><span class="chip chip--present">Seconde</span><span class="chip chip--present">Minute</span><span class="chip chip--present">Heure</span><span class="chip chip--present">Époque</span></div></div>
+          
+        </article>
+        <article class="card" id="flore---fleurs--plantes">
+          <div class="card-head">
+            <h3>Flore : fleurs, plantes</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:93%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">93 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (1 piste)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Glycine&quot;]">🔍 Révéler un indice (1 restant)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (14/15)</span><div class="chips"><span class="chip chip--present">Fougère</span><span class="chip chip--present">Bruyère</span><span class="chip chip--present">Marguerite</span><span class="chip chip--present">Jonquille</span><span class="chip chip--present">Aubépine</span><span class="chip chip--present">Ortie</span><span class="chip chip--present">Camomille</span><span class="chip chip--present">Lavande</span><span class="chip chip--present">Pâquerette</span><span class="chip chip--present">Clémentine</span><span class="chip chip--present">Groseille</span><span class="chip chip--present">Framboise</span><span class="chip chip--present">Myrtille</span><span class="chip chip--present">Luzerne</span></div></div>
+          
+        </article>
+        <article class="card" id="faune---animaux--insectes">
+          <div class="card-head">
+            <h3>Faune : animaux, insectes</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:94%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">94 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (1 piste)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Fourmi&quot;]">🔍 Révéler un indice (1 restant)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (15/16)</span><div class="chips"><span class="chip chip--present">Libellule</span><span class="chip chip--present">Coccinelle</span><span class="chip chip--present">Hirondelle</span><span class="chip chip--present">Baleine</span><span class="chip chip--present">Mygale</span><span class="chip chip--present">Araignée</span><span class="chip chip--present">Abeille</span><span class="chip chip--present">Chenille</span><span class="chip chip--present">Biche</span><span class="chip chip--present">Corneille</span><span class="chip chip--present">Grenouille</span><span class="chip chip--present">Hyène</span><span class="chip chip--present">Panthère</span><span class="chip chip--present">Murène</span><span class="chip chip--present">Otarie</span></div></div>
+          
+        </article>
+        <article class="card" id="vêtements---parures">
+          <div class="card-head">
+            <h3>Vêtements &amp; parures</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:100%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">100 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher</span>
+            <div class="chips"><span class="chip chip--done">rien ne manque !</span></div>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (13/13)</span><div class="chips"><span class="chip chip--present">Chemise</span><span class="chip chip--present">Ceinture</span><span class="chip chip--present">Cravate</span><span class="chip chip--present">Écharpe</span><span class="chip chip--present">Capuche</span><span class="chip chip--present">Jupe</span><span class="chip chip--present">Chaussette</span><span class="chip chip--present">Casquette</span><span class="chip chip--present">Robe</span><span class="chip chip--present">Veste</span><span class="chip chip--present">Cagoule</span><span class="chip chip--present">Mitaine</span><span class="chip chip--present">Chemisette</span></div></div>
+          
+        </article>
+        <article class="card" id="habitat---architecture">
+          <div class="card-head">
+            <h3>Habitat &amp; architecture</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:100%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">100 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher</span>
+            <div class="chips"><span class="chip chip--done">rien ne manque !</span></div>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (13/13)</span><div class="chips"><span class="chip chip--present">Chaumière</span><span class="chip chip--present">Cathédrale</span><span class="chip chip--present">Forteresse</span><span class="chip chip--present">Chapelle</span><span class="chip chip--present">Masure</span><span class="chip chip--present">Bâtisse</span><span class="chip chip--present">Citadelle</span><span class="chip chip--present">Abbaye</span><span class="chip chip--present">Bibliothèque</span><span class="chip chip--present">Ferme</span><span class="chip chip--present">Auberge</span><span class="chip chip--present">Caserne</span><span class="chip chip--present">Mairie</span></div></div>
+          
+        </article>
+      </div>
+    </section>
+    <section class="tier tier--partiel">
+      <h2 class="tier-node">Partiellement couverts <span class="count">12 champs</span></h2>
+      <div class="cards">
+        <article class="card" id="médecine--maux-du-corps">
+          <div class="card-head">
+            <h3>Médecine, maux du corps</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:40%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">40 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (18 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Bronchite&quot;, &quot;Arthrite&quot;, &quot;Appendicite&quot;, &quot;Névralgie&quot;, &quot;Claustrophobie&quot;, &quot;Agoraphobie&quot;, &quot;Hydrophobie&quot;, &quot;Tuberculose&quot;, &quot;Cirrhose&quot;, &quot;Gastrite&quot;, &quot;Otite&quot;, &quot;Laryngite&quot;, &quot;Conjonctivite&quot;, &quot;Dermatite&quot;, &quot;Hépatite&quot;, &quot;Angine&quot;, &quot;Anémie&quot;, &quot;Toux&quot;]">🔍 Révéler un indice (18 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (12/30)</span><div class="chips"><span class="chip chip--present">Mycose</span><span class="chip chip--present">Migraine</span><span class="chip chip--present">Anosmie</span><span class="chip chip--present">Agueusie</span><span class="chip chip--present">Allergie</span><span class="chip chip--present">Insomnie</span><span class="chip chip--present">Fracture</span><span class="chip chip--present">Entorse</span><span class="chip chip--present">Cicatrice</span><span class="chip chip--present">Blessure</span><span class="chip chip--present">Fièvre</span><span class="chip chip--present">Nausée</span></div></div>
+          <p class="note">les symptômes du quotidien passent, le jargon savant en -ite/-ose résiste</p>
+        </article>
+        <article class="card" id="parenté-proche">
+          <div class="card-head">
+            <h3>Parenté proche</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:41%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">41 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (10 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Fille&quot;, &quot;Nièce&quot;, &quot;Marraine&quot;, &quot;Filleule&quot;, &quot;Belle-Mère&quot;, &quot;Grand-Mère&quot;, &quot;Matriarche&quot;, &quot;Bru&quot;, &quot;Épouse&quot;, &quot;Fiancée&quot;]">🔍 Révéler un indice (10 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (7/17)</span><div class="chips"><span class="chip chip--present">Mère</span><span class="chip chip--present">Sœur</span><span class="chip chip--present">Tante</span><span class="chip chip--present">Cousine</span><span class="chip chip--present">Aïeule</span><span class="chip chip--present">Veuve</span><span class="chip chip--present">Concubine</span></div></div>
+          <p class="note">le cercle proche est couvert, la parentèle plus éloignée beaucoup moins</p>
+        </article>
+        <article class="card" id="écologie---environnement">
+          <div class="card-head">
+            <h3>Écologie &amp; environnement</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:42%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">42 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (7 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Pollution&quot;, &quot;Recyclage&quot;, &quot;Reforestation&quot;, &quot;Déforestation&quot;, &quot;Canicule&quot;, &quot;Permaculture&quot;, &quot;Écosystème&quot;]">🔍 Révéler un indice (7 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (5/12)</span><div class="chips"><span class="chip chip--present">Biodiversité</span><span class="chip chip--present">Surpêche</span><span class="chip chip--present">Sécheresse</span><span class="chip chip--present">Empreinte</span><span class="chip chip--present">Transition</span></div></div>
+          
+        </article>
+        <article class="card" id="couleurs-nommées">
+          <div class="card-head">
+            <h3>Couleurs nommées</h3>
+            <span class="tag">noms & adjectifs</span>
+          </div>
+          <div class="gauge" style="--pct:47%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">47 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (10 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Turquoise&quot;, &quot;Indigo&quot;, &quot;Ocre&quot;, &quot;Ivoire&quot;, &quot;Corail&quot;, &quot;Incarnate&quot;, &quot;Safran&quot;, &quot;Kaki&quot;, &quot;Beige&quot;, &quot;Opaline&quot;]">🔍 Révéler un indice (10 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (9/19)</span><div class="chips"><span class="chip chip--present">Rose</span><span class="chip chip--present">Mauve</span><span class="chip chip--present">Pourpre</span><span class="chip chip--present">Vermeille</span><span class="chip chip--present">Écarlate</span><span class="chip chip--present">Cramoisie</span><span class="chip chip--present">Argentée</span><span class="chip chip--present">Dorée</span><span class="chip chip--present">Cuivrée</span></div></div>
+          <p class="note">champ pénalisé par la grammaire : une couleur est un nom masculin par défaut (« le rouge »), or le corpus est presque tout féminin</p>
+        </article>
+        <article class="card" id="religion---liturgie">
+          <div class="card-head">
+            <h3>Religion &amp; liturgie</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:48%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">48 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (12 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Absolution&quot;, &quot;Communion&quot;, &quot;Liturgie&quot;, &quot;Confession&quot;, &quot;Messe&quot;, &quot;Procession&quot;, &quot;Dévotion&quot;, &quot;Idolâtrie&quot;, &quot;Canonisation&quot;, &quot;Excommunication&quot;, &quot;Résurrection&quot;, &quot;Transsubstantiation&quot;]">🔍 Révéler un indice (12 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (11/23)</span><div class="chips"><span class="chip chip--present">Bénédiction</span><span class="chip chip--present">Providence</span><span class="chip chip--present">Prière</span><span class="chip chip--present">Foi</span><span class="chip chip--present">Grâce</span><span class="chip chip--present">Offrande</span><span class="chip chip--present">Hérésie</span><span class="chip chip--present">Apparition</span><span class="chip chip--present">Ascension</span><span class="chip chip--present">Annonciation</span><span class="chip chip--present">Épiphanie</span></div></div>
+          <p class="note">vocabulaire chrétien surtout ; les autres traditions religieuses sont un angle mort</p>
+        </article>
+        <article class="card" id="vocabulaire-logiciel---dev">
+          <div class="card-head">
+            <h3>Vocabulaire logiciel / dev</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:53%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">53 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (9 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Numérisation&quot;, &quot;Robotique&quot;, &quot;Informatique&quot;, &quot;Algorithme&quot;, &quot;Cybersécurité&quot;, &quot;Donnée&quot;, &quot;Synchronisation&quot;, &quot;Virtualisation&quot;, &quot;Modélisation&quot;]">🔍 Révéler un indice (9 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (10/19)</span><div class="chips"><span class="chip chip--present">Application</span><span class="chip chip--present">Connexion</span><span class="chip chip--present">Interface</span><span class="chip chip--present">Plateforme</span><span class="chip chip--present">Intelligence</span><span class="chip chip--present">Base</span><span class="chip chip--present">Messagerie</span><span class="chip chip--present">Notification</span><span class="chip chip--present">Instanciation</span><span class="chip chip--present">Journalisation</span></div></div>
+          <p class="note">un clin d&#x27;œil facile pour qui code : ce champ parlera à Lucas plus qu&#x27;au grand public</p>
+        </article>
+        <article class="card" id="anatomie--corps-humain">
+          <div class="card-head">
+            <h3>Anatomie, corps humain</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:60%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">60 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (6 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Hanche&quot;, &quot;Rotule&quot;, &quot;Rétine&quot;, &quot;Aisselle&quot;, &quot;Omoplate&quot;, &quot;Phalange&quot;]">🔍 Révéler un indice (6 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (9/15)</span><div class="chips"><span class="chip chip--present">Clavicule</span><span class="chip chip--present">Mâchoire</span><span class="chip chip--present">Nuque</span><span class="chip chip--present">Cheville</span><span class="chip chip--present">Paupière</span><span class="chip chip--present">Narine</span><span class="chip chip--present">Cuisse</span><span class="chip chip--present">Gencive</span><span class="chip chip--present">Vertèbre</span></div></div>
+          <p class="note">le noyau (visage, membres) est souvent là ; les organes internes, moins</p>
+        </article>
+        <article class="card" id="droit--justice--politique">
+          <div class="card-head">
+            <h3>Droit, justice, politique</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:60%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">60 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (4 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Sanction&quot;, &quot;Souveraineté&quot;, &quot;Juridiction&quot;, &quot;Législation&quot;]">🔍 Révéler un indice (4 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (6/10)</span><div class="chips"><span class="chip chip--present">Constitution</span><span class="chip chip--present">Ordonnance</span><span class="chip chip--present">Citoyenneté</span><span class="chip chip--present">Élection</span><span class="chip chip--present">Démocratie</span><span class="chip chip--present">Monarchie</span></div></div>
+          
+        </article>
+        <article class="card" id="sport---activités-physiques">
+          <div class="card-head">
+            <h3>Sport &amp; activités physiques</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:60%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">60 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (6 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Randonnée&quot;, &quot;Boxe&quot;, &quot;Escrime&quot;, &quot;Équitation&quot;, &quot;Aviron&quot;, &quot;Ski&quot;]">🔍 Révéler un indice (6 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (9/15)</span><div class="chips"><span class="chip chip--present">Natation</span><span class="chip chip--present">Gymnastique</span><span class="chip chip--present">Compétition</span><span class="chip chip--present">Course</span><span class="chip chip--present">Mêlée</span><span class="chip chip--present">Escalade</span><span class="chip chip--present">Plongée</span><span class="chip chip--present">Lutte</span><span class="chip chip--present">Voile</span></div></div>
+          
+        </article>
+        <article class="card" id="espace--astronomie-concrète">
+          <div class="card-head">
+            <h3>Espace, astronomie concrète</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:60%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">60 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (4 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Supernova&quot;, &quot;Constellation&quot;, &quot;Exoplanète&quot;, &quot;Astéroïde&quot;]">🔍 Révéler un indice (4 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (6/10)</span><div class="chips"><span class="chip chip--present">Comète</span><span class="chip chip--present">Galaxie</span><span class="chip chip--present">Nébuleuse</span><span class="chip chip--present">Étoile</span><span class="chip chip--present">Météorite</span><span class="chip chip--present">Orbite</span></div></div>
+          
+        </article>
+        <article class="card" id="registre-familier-léger">
+          <div class="card-head">
+            <h3>Registre familier léger</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:60%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">60 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (4 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Fringue&quot;, &quot;Combine&quot;, &quot;Provoc&quot;, &quot;Tune&quot;]">🔍 Révéler un indice (4 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (6/10)</span><div class="chips"><span class="chip chip--present">Bagnole</span><span class="chip chip--present">Gueule</span><span class="chip chip--present">Bouffe</span><span class="chip chip--present">Galère</span><span class="chip chip--present">Embrouille</span><span class="chip chip--present">Cagoule</span></div></div>
+          
+        </article>
+        <article class="card" id="tailles---formes">
+          <div class="card-head">
+            <h3>Tailles &amp; formes</h3>
+            <span class="tag">adjectifs</span>
+          </div>
+          <div class="gauge" style="--pct:67%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">67 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (3 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Vaste&quot;, &quot;Difforme&quot;, &quot;Concave&quot;]">🔍 Révéler un indice (3 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (6/9)</span><div class="chips"><span class="chip chip--present">Ronde</span><span class="chip chip--present">Carrée</span><span class="chip chip--present">Étroite</span><span class="chip chip--present">Massive</span><span class="chip chip--present">Oblongue</span><span class="chip chip--present">Convexe</span></div></div>
+          
+        </article>
+      </div>
+    </section>
+    <section class="tier tier--non">
+      <h2 class="tier-node">Peu ou pas couverts <span class="count">2 champs</span></h2>
+      <div class="cards">
+        <article class="card" id="numérique-grand-public--ia--réseaux--smartphone">
+          <div class="card-head">
+            <h3>Numérique grand public (IA, réseaux, smartphone)</h3>
+            <span class="tag">noms</span>
+          </div>
+          <div class="gauge" style="--pct:19%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">19 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (13 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Robotique&quot;, &quot;Cybersécurité&quot;, &quot;Réseau-Social&quot;, &quot;Story&quot;, &quot;Selfie&quot;, &quot;Vidéoconférence&quot;, &quot;Géolocalisation&quot;, &quot;Authentification&quot;, &quot;Biométrie&quot;, &quot;Domotique&quot;, &quot;Réalité-Virtuelle&quot;, &quot;Blockchain&quot;, &quot;Cryptomonnaie&quot;]">🔍 Révéler un indice (13 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (3/16)</span><div class="chips"><span class="chip chip--present">Publication</span><span class="chip chip--present">Notification</span><span class="chip chip--present">Messagerie</span></div></div>
+          <p class="note">quasi vierge : bon terrain de chasse si le corpus doit parler du monde d&#x27;aujourd&#x27;hui</p>
+        </article>
+        <article class="card" id="parenté-par-adjectif--filiation">
+          <div class="card-head">
+            <h3>Parenté par adjectif (filiation)</h3>
+            <span class="tag">adjectifs</span>
+          </div>
+          <div class="gauge" style="--pct:25%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">25 %</span>
+          </div>
+          <div class="missing-row">
+            <span class="missing-label">à chercher (9 pistes)</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="[&quot;Maternelle&quot;, &quot;Paternelle&quot;, &quot;Fraternelle&quot;, &quot;Filiale&quot;, &quot;Conjugale&quot;, &quot;Matrimoniale&quot;, &quot;Gémellaire&quot;, &quot;Veuve&quot;, &quot;Célibataire&quot;]">🔍 Révéler un indice (9 restants)</button>
+          </div>
+          <div class="present-row"><span class="present-label">déjà présents (3/12)</span><div class="chips"><span class="chip chip--present">Ancestrale</span><span class="chip chip--present">Cousine</span><span class="chip chip--present">Adoptive</span></div></div>
+          
+        </article>
+      </div>
+    </section>
+  </div>
+
+  <footer class="legend">
+    <p><b>Méthode</b> — chaque champ est une liste-témoin de 8 à 30 mots caractéristiques,
+    vérifiée mot à mot (insensible à la casse) contre le corpus actuel. Un champ à 90 % n'a
+    pas forcément 90 % du vocabulaire français du domaine — seulement 90 % des mots-témoins
+    choisis. Les tiers (bien / partiellement / peu couverts) sont recalculés à chaque
+    génération, à partir de l'état courant du corpus.</p>
+    <p>généré le 2026-07-27 07:54 UTC</p>
+  </footer>
+</main>
+
+<script>
+  document.addEventListener("click", function (event) {
+    var btn = event.target.closest(".reveal-btn");
+    if (!btn || btn.disabled) return;
+    var pool;
+    try {
+      pool = JSON.parse(btn.dataset.pool || "[]");
+    } catch (err) {
+      pool = [];
+    }
+    if (!pool.length) return;
+    var index = Math.floor(Math.random() * pool.length);
+    var word = pool.splice(index, 1)[0];
+    btn.dataset.pool = JSON.stringify(pool);
+    var chip = document.createElement("span");
+    chip.className = "chip chip--revealed";
+    chip.textContent = word;
+    btn.parentElement.querySelector(".reveal-chips").appendChild(chip);
+    if (pool.length > 0) {
+      btn.textContent = "\ud83d\udd0d R\u00e9v\u00e9ler un indice (" + pool.length + " restant" + (pool.length > 1 ? "s" : "") + ")";
+    } else {
+      btn.textContent = "\u2713 Tout est sorti";
+      btn.disabled = true;
+    }
+  });
+</script>

--- a/lexical_report.py
+++ b/lexical_report.py
@@ -1,0 +1,589 @@
+#!/usr/bin/env python3
+"""Generate an HTML report of lexical fields covered/missing in lully/words.py.
+
+For each hand-picked semantic field, a small set of representative French
+words is checked against the current NOUNS/ADJECTIVES tuples. The report
+highlights, per field, which of those representative words are still absent
+from the corpus — a checklist for humans hunting for words to add with
+addwords.py.
+
+Usage:
+    python lexical_report.py [--words lully/words.py] [--out docs/index.html]
+"""
+import argparse
+import ast
+import json
+import os
+import html as html_lib
+from datetime import datetime, timezone
+
+
+# (field name, "N" nom / "A" adjectif / "N+A" les deux, mots-témoins, note optionnelle)
+FIELDS = [
+    ("Figures de style & rhétorique", "N", [
+        "anacoluthe", "antanaclase", "antonomase", "asyndète", "litote", "métaphore",
+        "métonymie", "anaphore", "antithèse", "paronomase", "hyperbate", "parembole",
+        "allitération", "anadiplose", "apostrophe", "hypallage", "hyperbole", "allégorie",
+        "synecdoque", "chiasme", "oxymore", "zeugme", "ellipse", "antiphrase", "périphrase",
+        "tautologie", "gradation", "comparaison", "personnification",
+    ], ""),
+    ("Sciences savantes en -logie / -graphie", "N", [
+        "biologie", "astronomie", "anthropologie", "cristallographie", "démographie",
+        "géologie", "sociologie", "psychologie", "chronologie", "météorologie",
+        "cartographie", "bibliographie", "numismatique", "botanique", "zoologie",
+        "criminologie", "climatologie", "ethnologie", "phonologie", "morphologie", "physiologie",
+    ], ""),
+    ("Métiers & professions féminisées", "N", [
+        "institutrice", "avocate", "danseuse", "chercheuse", "journaliste", "pianiste",
+        "bibliothécaire", "infirmière", "architecte", "biographe", "astronome", "actrice",
+        "autrice", "conductrice", "ouvrière", "couturière", "boulangère", "artificière",
+        "chirurgienne", "juriste",
+    ], ""),
+    ("Émotions & états d'âme", "N", [
+        "joie", "tristesse", "angoisse", "nostalgie", "mélancolie", "extase", "frayeur",
+        "colère", "ardeur", "peur", "honte", "fierté", "jalousie", "envie", "allégresse",
+        "désolation", "inquiétude", "anxiété", "exaltation", "consternation",
+    ], ""),
+    ("Flore : fleurs, plantes", "N", [
+        "fougère", "bruyère", "marguerite", "jonquille", "aubépine", "ortie", "camomille",
+        "lavande", "glycine", "pâquerette", "clémentine", "groseille", "framboise",
+        "myrtille", "luzerne",
+    ], ""),
+    ("Faune : animaux, insectes", "N", [
+        "libellule", "coccinelle", "hirondelle", "baleine", "mygale", "araignée", "fourmi",
+        "abeille", "chenille", "biche", "corneille", "grenouille", "hyène", "panthère",
+        "murène", "otarie",
+    ], ""),
+    ("Vêtements & parures", "N", [
+        "chemise", "ceinture", "cravate", "écharpe", "capuche", "jupe", "chaussette",
+        "casquette", "robe", "veste", "cagoule", "mitaine", "chemisette",
+    ], ""),
+    ("Habitat & architecture", "N", [
+        "chaumière", "cathédrale", "forteresse", "chapelle", "masure", "bâtisse",
+        "citadelle", "abbaye", "bibliothèque", "ferme", "auberge", "caserne", "mairie",
+    ], ""),
+    ("Objets & outils du quotidien", "N", [
+        "pince", "fourchette", "cuillère", "casserole", "bouilloire", "aiguille", "épingle",
+        "brosse", "éponge", "bassine", "louche", "lime",
+    ], ""),
+    ("Musique, danse, instruments", "N", [
+        "guitare", "cornemuse", "harpe", "clarinette", "chorale", "gigue", "cymbale",
+        "flûte", "mandoline", "sarabande", "tarentelle", "polka",
+    ], ""),
+    ("Armement & guerre", "N", [
+        "arquebuse", "cuirasse", "armure", "artillerie", "bataille", "embuscade", "arbalète",
+        "hallebarde", "baïonnette", "catapulte", "garnison",
+    ], ""),
+    ("Temps & durée", "N", [
+        "décennie", "journée", "matinée", "soirée", "éternité", "semaine", "année",
+        "seconde", "minute", "heure", "époque", "ère",
+    ], ""),
+    ("Cuisine & gourmandise", "N", [
+        "confiture", "choucroute", "fondue", "marmelade", "charcuterie", "pâtisserie",
+        "brioche", "omelette", "soupe", "compote", "confiserie",
+    ], ""),
+    ("Relief & paysages d'eau", "N", [
+        "montagne", "vallée", "rivière", "falaise", "colline", "plaine", "presqu'île",
+        "péninsule", "crique", "lagune", "cascade",
+    ], ""),
+    ("Finance & économie", "N", [
+        "banque", "bourse", "capitalisation", "liquidité", "dette", "monnaie", "fortune",
+        "prospérité", "inflation", "récession", "spéculation", "économie", "rentabilité",
+        "solvabilité",
+    ], ""),
+    ("Textures & matières", "A", [
+        "rugueuse", "lisse", "soyeuse", "visqueuse", "granuleuse", "poreuse", "élastique",
+        "collante", "huileuse", "cotonneuse",
+    ], ""),
+    ("Sciences & techniques en -ique", "A", [
+        "chimique", "biologique", "électrique", "magnétique", "acoustique", "génétique",
+        "atomique", "numérique", "mécanique", "organique",
+    ], ""),
+    ("Saveurs", "A", [
+        "sucrée", "salée", "amère", "acide", "épicée", "fade", "savoureuse", "insipide",
+    ], ""),
+    ("États émotionnels", "A", [
+        "joyeuse", "triste", "anxieuse", "sereine", "mélancolique", "exaltée", "apaisée",
+        "furieuse", "radieuse", "morose",
+    ], ""),
+    ("Anatomie, corps humain", "N", [
+        "clavicule", "mâchoire", "nuque", "cheville", "paupière", "narine", "cuisse",
+        "hanche", "gencive", "rotule", "rétine", "aisselle", "omoplate", "phalange", "vertèbre",
+    ], "le noyau (visage, membres) est souvent là ; les organes internes, moins"),
+    ("Médecine, maux du corps", "N", [
+        "bronchite", "arthrite", "appendicite", "mycose", "névralgie", "claustrophobie",
+        "agoraphobie", "hydrophobie", "migraine", "tuberculose", "anosmie", "agueusie",
+        "cirrhose", "gastrite", "otite", "laryngite", "conjonctivite", "dermatite",
+        "hépatite", "angine", "allergie", "insomnie", "anémie", "fracture", "entorse",
+        "cicatrice", "blessure", "fièvre", "toux", "nausée",
+    ], "les symptômes du quotidien passent, le jargon savant en -ite/-ose résiste"),
+    ("Religion & liturgie", "N", [
+        "bénédiction", "absolution", "communion", "providence", "liturgie", "prière",
+        "confession", "messe", "procession", "dévotion", "foi", "grâce", "offrande",
+        "idolâtrie", "hérésie", "canonisation", "excommunication", "apparition",
+        "résurrection", "ascension", "annonciation", "épiphanie", "transsubstantiation",
+    ], "vocabulaire chrétien surtout ; les autres traditions religieuses sont un angle mort"),
+    ("Droit, justice, politique", "N", [
+        "constitution", "sanction", "ordonnance", "souveraineté", "juridiction",
+        "législation", "citoyenneté", "élection", "démocratie", "monarchie",
+    ], ""),
+    ("Vocabulaire logiciel / dev", "N", [
+        "application", "numérisation", "robotique", "informatique", "connexion",
+        "interface", "plateforme", "algorithme", "cybersécurité", "intelligence", "base",
+        "donnée", "messagerie", "notification", "synchronisation", "virtualisation",
+        "modélisation", "instanciation", "journalisation",
+    ], "un clin d'œil facile pour qui code : ce champ parlera à Lucas plus qu'au grand public"),
+    ("Parenté proche", "N", [
+        "mère", "sœur", "fille", "tante", "nièce", "cousine", "marraine", "filleule",
+        "belle-mère", "grand-mère", "aïeule", "matriarche", "bru", "veuve", "épouse",
+        "fiancée", "concubine",
+    ], "le cercle proche est couvert, la parentèle plus éloignée beaucoup moins"),
+    ("Sport & activités physiques", "N", [
+        "natation", "gymnastique", "compétition", "course", "mêlée", "escalade",
+        "randonnée", "plongée", "boxe", "lutte", "escrime", "équitation", "voile",
+        "aviron", "ski",
+    ], ""),
+    ("Écologie & environnement", "N", [
+        "biodiversité", "pollution", "recyclage", "reforestation", "surpêche",
+        "déforestation", "canicule", "sécheresse", "empreinte", "transition",
+        "permaculture", "écosystème",
+    ], ""),
+    ("Espace, astronomie concrète", "N", [
+        "comète", "galaxie", "nébuleuse", "étoile", "supernova", "constellation",
+        "météorite", "exoplanète", "orbite", "astéroïde",
+    ], ""),
+    ("Registre familier léger", "N", [
+        "bagnole", "gueule", "fringue", "bouffe", "galère", "embrouille", "combine",
+        "cagoule", "provoc", "tune",
+    ], ""),
+    ("Couleurs nommées", "N+A", [
+        "rose", "mauve", "pourpre", "vermeille", "écarlate", "turquoise", "indigo", "ocre",
+        "ivoire", "corail", "cramoisie", "incarnate", "safran", "kaki", "beige", "argentée",
+        "dorée", "cuivrée", "opaline",
+    ], "champ pénalisé par la grammaire : une couleur est un nom masculin par défaut "
+       "(« le rouge »), or le corpus est presque tout féminin"),
+    ("Tailles & formes", "A", [
+        "ronde", "carrée", "étroite", "vaste", "massive", "difforme", "oblongue",
+        "concave", "convexe",
+    ], ""),
+    ("Parenté par adjectif (filiation)", "A", [
+        "maternelle", "paternelle", "fraternelle", "filiale", "conjugale", "matrimoniale",
+        "ancestrale", "cousine", "gémellaire", "adoptive", "veuve", "célibataire",
+    ], ""),
+    ("Numérique grand public (IA, réseaux, smartphone)", "N", [
+        "robotique", "cybersécurité", "réseau-social", "publication", "story",
+        "notification", "selfie", "messagerie", "vidéoconférence", "géolocalisation",
+        "authentification", "biométrie", "domotique", "réalité-virtuelle", "blockchain",
+        "cryptomonnaie",
+    ], "quasi vierge : bon terrain de chasse si le corpus doit parler du monde d'aujourd'hui"),
+]
+
+TIER_BOUNDS = [
+    ("bien", "Bien couverts", 70),
+    ("partiel", "Partiellement couverts", 40),
+    ("non", "Peu ou pas couverts", 0),
+]
+
+
+def load_words(path):
+    with open(path, encoding="utf-8") as f:
+        src = f.read()
+    tree = ast.parse(src, filename=path)
+    ns = {}
+    exec(compile(tree, path, "exec"), ns)
+    return ns["NOUNS"], ns["ADJECTIVES"]
+
+
+def tier_for(pct):
+    for key, label, floor in TIER_BOUNDS:
+        if pct >= floor:
+            return key, label
+    return TIER_BOUNDS[-1][0], TIER_BOUNDS[-1][1]
+
+
+def analyze(nouns, adjectives):
+    nouns_lc = {w.lower() for w in nouns}
+    adj_lc = {w.lower() for w in adjectives}
+    results = []
+    for name, typ, diag, note in FIELDS:
+        if typ == "N+A":
+            lexicon = nouns_lc | adj_lc
+        elif typ == "A":
+            lexicon = adj_lc
+        else:
+            lexicon = nouns_lc
+        present = [w for w in diag if w in lexicon]
+        missing = [w for w in diag if w not in lexicon]
+        pct = round(100 * len(present) / len(diag))
+        tier_key, tier_label = tier_for(pct)
+        results.append({
+            "name": name, "type": typ, "note": note,
+            "pct": pct, "present": present, "missing": missing,
+            "tier_key": tier_key, "tier_label": tier_label,
+        })
+    return results
+
+
+def esc(s):
+    return html_lib.escape(s, quote=True)
+
+
+def slugify(name):
+    return "".join(c if c.isalnum() else "-" for c in name.lower()).strip("-")
+
+
+def card_html(field):
+    type_label = {"N": "noms", "A": "adjectifs", "N+A": "noms & adjectifs"}[field["type"]]
+    missing_words = [w.title() for w in field["missing"]]
+    present_chips = "".join(
+        f'<span class="chip chip--present">{esc(w.title())}</span>' for w in field["present"]
+    )
+    note_html = f'<p class="note">{esc(field["note"])}</p>' if field["note"] else ""
+    present_row = (
+        f'<div class="present-row"><span class="present-label">déjà présents ({len(field["present"])}/{len(field["present"]) + len(field["missing"])})</span>'
+        f'<div class="chips">{present_chips}</div></div>'
+        if present_chips else ""
+    )
+
+    if missing_words:
+        pool_json = esc(json.dumps(missing_words, ensure_ascii=False))
+        n = len(missing_words)
+        missing_html = f"""<div class="missing-row">
+            <span class="missing-label">à chercher ({n} piste{'s' if n > 1 else ''})</span>
+            <div class="chips reveal-chips"></div>
+            <button type="button" class="reveal-btn" data-pool="{pool_json}">🔍 Révéler un indice ({n} restant{'s' if n > 1 else ''})</button>
+          </div>"""
+    else:
+        missing_html = """<div class="missing-row">
+            <span class="missing-label">à chercher</span>
+            <div class="chips"><span class="chip chip--done">rien ne manque !</span></div>
+          </div>"""
+
+    return f"""
+        <article class="card" id="{slugify(field['name'])}">
+          <div class="card-head">
+            <h3>{esc(field['name'])}</h3>
+            <span class="tag">{type_label}</span>
+          </div>
+          <div class="gauge" style="--pct:{field['pct']}%">
+            <div class="gauge-fill"></div>
+            <span class="gauge-label">{field['pct']} %</span>
+          </div>
+          {missing_html}
+          {present_row}
+          {note_html}
+        </article>"""
+
+
+def build_html(nouns, adjectives, source_label=""):
+    results = analyze(nouns, adjectives)
+    by_tier = {"bien": [], "partiel": [], "non": []}
+    for r in results:
+        by_tier[r["tier_key"]].append(r)
+    for key in by_tier:
+        by_tier[key].sort(key=lambda r: r["pct"])  # weakest first: what to tackle first
+
+    priority = sorted(results, key=lambda r: r["pct"])[:8]
+    priority_html = "".join(
+        f'<li><a href="#{slugify(r["name"])}">{esc(r["name"])}</a> '
+        f'<span class="prio-pct">{r["pct"]}&nbsp;%</span></li>'
+        for r in priority
+    )
+
+    sections_html = ""
+    for key, label, _ in TIER_BOUNDS:
+        cards = "".join(card_html(r) for r in by_tier[key])
+        sections_html += f"""
+    <section class="tier tier--{key}">
+      <h2 class="tier-node">{label} <span class="count">{len(by_tier[key])} champs</span></h2>
+      <div class="cards">{cards}
+      </div>
+    </section>"""
+
+    generated_line = f"généré {source_label}" if source_label else ""
+
+    return TEMPLATE.format(
+        n_nouns=len(nouns), n_adj=len(adjectives),
+        n_fields=len(results),
+        priority_html=priority_html,
+        sections_html=sections_html,
+        generated_line=esc(generated_line),
+    )
+
+
+TEMPLATE = """<title>Lully — champs lexicaux à compléter</title>
+<style>
+  @media (prefers-color-scheme: light) {{ :root {{ color-scheme: light; }} }}
+  @media (prefers-color-scheme: dark) {{ :root {{ color-scheme: dark; }} }}
+
+  :root {{
+    --paper: #e7e2d2;
+    --paper-raised: #f4f0e2;
+    --ink: #22291f;
+    --ink-soft: #5a5d4d;
+    --line: #c9c2a4;
+    --bien: #3f6b45;
+    --bien-soft: #dbe6d7;
+    --partiel: #a2793a;
+    --partiel-soft: #ecdfc5;
+    --non: #8c3f33;
+    --non-soft: #ecd8d2;
+    --missing: #8c3f33;
+    --missing-soft: #f3e2dc;
+    --font-display: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, "Times New Roman", serif;
+    --font-body: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+  }}
+  @media (prefers-color-scheme: dark) {{
+    :root {{
+      --paper: #1b211c; --paper-raised: #232921; --ink: #e9e4d3; --ink-soft: #a9a491;
+      --line: #3c4335; --bien: #7cb583; --bien-soft: #2b3a2c; --partiel: #d3a463;
+      --partiel-soft: #3a3221; --non: #cf7767; --non-soft: #3c2723;
+      --missing: #d98871; --missing-soft: #3a2924;
+    }}
+  }}
+  :root[data-theme="dark"] {{
+    --paper: #1b211c; --paper-raised: #232921; --ink: #e9e4d3; --ink-soft: #a9a491;
+    --line: #3c4335; --bien: #7cb583; --bien-soft: #2b3a2c; --partiel: #d3a463;
+    --partiel-soft: #3a3221; --non: #cf7767; --non-soft: #3c2723;
+    --missing: #d98871; --missing-soft: #3a2924;
+  }}
+  :root[data-theme="light"] {{
+    --paper: #e7e2d2; --paper-raised: #f4f0e2; --ink: #22291f; --ink-soft: #5a5d4d;
+    --line: #c9c2a4; --bien: #3f6b45; --bien-soft: #dbe6d7; --partiel: #a2793a;
+    --partiel-soft: #ecdfc5; --non: #8c3f33; --non-soft: #ecd8d2;
+    --missing: #8c3f33; --missing-soft: #f3e2dc;
+  }}
+
+  * {{ box-sizing: border-box; }}
+  html, body {{ margin: 0; padding: 0; }}
+  body {{
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--font-body);
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+  }}
+  main {{ max-width: 880px; margin: 0 auto; padding: 2.25rem 1.25rem 5rem; }}
+
+  header.page-head {{ margin-bottom: 2.25rem; }}
+  .eyebrow {{
+    font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.14em;
+    text-transform: uppercase; color: var(--ink-soft);
+  }}
+  h1 {{
+    font-family: var(--font-display); font-weight: 600;
+    font-size: clamp(1.6rem, 5vw, 2.35rem); margin: 0.35rem 0 0.6rem; text-wrap: balance;
+  }}
+  .lede {{ max-width: 62ch; color: var(--ink-soft); font-size: 0.98rem; }}
+  .lede b {{ color: var(--ink); font-weight: 600; }}
+
+  .stats {{ display: flex; gap: 1.5rem; margin-top: 1.15rem; flex-wrap: wrap; }}
+  .stat {{ font-family: var(--font-mono); font-variant-numeric: tabular-nums; }}
+  .stat .n {{ font-size: 1.3rem; color: var(--ink); }}
+  .stat .l {{
+    display: block; font-size: 0.68rem; color: var(--ink-soft);
+    letter-spacing: 0.06em; text-transform: uppercase;
+  }}
+
+  .priority {{
+    margin: 1.5rem 0 0;
+    padding: 0.9rem 1rem;
+    background: var(--missing-soft);
+    border-left: 3px solid var(--missing);
+    border-radius: 0 3px 3px 0;
+  }}
+  .priority h2 {{
+    font-family: var(--font-display); font-size: 1.05rem; margin: 0 0 0.5rem;
+  }}
+  .priority ol {{ margin: 0; padding-left: 1.2rem; columns: 2; column-gap: 1.5rem; }}
+  .priority li {{ font-size: 0.88rem; margin-bottom: 0.25rem; break-inside: avoid; }}
+  .priority a {{ color: var(--ink); }}
+  .prio-pct {{ font-family: var(--font-mono); font-size: 0.75rem; color: var(--ink-soft); }}
+
+  .tree {{ position: relative; margin-left: 0.6rem; padding-left: 1.6rem; border-left: 3px solid var(--line); margin-top: 2rem; }}
+  .tier {{ position: relative; margin-bottom: 2.75rem; }}
+  .tier:last-child {{ margin-bottom: 0; }}
+  .tier-node {{
+    position: relative; display: flex; align-items: baseline; gap: 0.6rem;
+    font-family: var(--font-display); font-size: 1.28rem; font-weight: 600;
+    margin: 0 0 1.1rem; padding-bottom: 0.5rem; border-bottom: 1px solid var(--line);
+  }}
+  .tier-node::before {{
+    content: ""; position: absolute; left: -1.98rem; top: 0.55em;
+    width: 1.3rem; height: 3px; background: var(--dot);
+  }}
+  .tier-node::after {{
+    content: ""; position: absolute; left: -2.35rem; top: 0.35em;
+    width: 0.85rem; height: 0.85rem; border-radius: 50%;
+    background: var(--paper); border: 3px solid var(--dot);
+  }}
+  .tier--bien {{ --dot: var(--bien); }}
+  .tier--partiel {{ --dot: var(--partiel); }}
+  .tier--non {{ --dot: var(--non); }}
+  .tier-node .count {{ font-family: var(--font-mono); font-size: 0.85rem; font-weight: 400; color: var(--ink-soft); }}
+
+  .cards {{ display: grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); gap: 0.85rem; }}
+
+  .card {{
+    background: var(--paper-raised); border: 1px solid var(--line);
+    border-left: 4px solid var(--dot); border-radius: 3px; padding: 0.85rem 0.95rem 0.95rem;
+    scroll-margin-top: 1rem;
+  }}
+  .card-head {{ display: flex; justify-content: space-between; align-items: baseline; gap: 0.5rem; margin-bottom: 0.55rem; }}
+  .card h3 {{ font-family: var(--font-display); font-size: 1.02rem; font-weight: 600; margin: 0; text-wrap: balance; }}
+  .tag {{
+    flex: none; font-family: var(--font-mono); font-size: 0.62rem; letter-spacing: 0.05em;
+    text-transform: uppercase; color: var(--ink-soft); border: 1px solid var(--line);
+    border-radius: 2px; padding: 0.1rem 0.35rem; white-space: nowrap;
+  }}
+  .gauge {{
+    position: relative; height: 0.55rem; background: var(--paper); border: 1px solid var(--line);
+    border-radius: 2px; margin-bottom: 0.75rem; overflow: hidden;
+  }}
+  .gauge-fill {{ position: absolute; inset: 0; width: var(--pct); background: var(--dot); border-radius: 2px 0 0 2px; }}
+  .gauge-label {{
+    position: absolute; right: 0.35rem; top: -1.2rem; font-family: var(--font-mono);
+    font-size: 0.7rem; font-variant-numeric: tabular-nums; color: var(--ink-soft);
+  }}
+  .chips {{ display: flex; flex-wrap: wrap; gap: 0.3rem; }}
+  .chip {{ font-size: 0.76rem; border-radius: 20px; padding: 0.12rem 0.55rem; }}
+  .chip--missing {{
+    background: transparent; color: var(--missing); border: 1px dashed var(--missing);
+  }}
+  .chip--done {{ font-style: italic; color: var(--ink-soft); border: 1px solid var(--line); }}
+  .chip--present {{ background: var(--paper); color: var(--ink-soft); border: 1px solid var(--line); }}
+  .missing-row {{ margin-bottom: 0.5rem; }}
+  .missing-label, .present-label {{
+    display: block; font-family: var(--font-mono); font-size: 0.65rem; letter-spacing: 0.04em;
+    text-transform: uppercase; margin-bottom: 0.3rem;
+  }}
+  .missing-label {{ color: var(--missing); }}
+  .present-label {{ color: var(--ink-soft); }}
+  .present-row {{ margin-top: 0.55rem; padding-top: 0.55rem; border-top: 1px dashed var(--line); }}
+  .note {{ margin: 0.55rem 0 0; font-size: 0.78rem; color: var(--ink-soft); font-style: italic; }}
+
+  .reveal-chips:empty {{ display: none; }}
+  .reveal-chips {{ margin-bottom: 0.4rem; }}
+  .reveal-btn {{
+    font-family: var(--font-mono); font-size: 0.68rem; letter-spacing: 0.02em;
+    color: var(--missing); background: var(--missing-soft); border: 1px solid var(--missing);
+    border-radius: 20px; padding: 0.28rem 0.7rem; cursor: pointer;
+  }}
+  .reveal-btn:hover {{ filter: brightness(1.08); }}
+  .reveal-btn:disabled {{
+    cursor: default; color: var(--ink-soft); background: transparent;
+    border-color: var(--line); filter: none;
+  }}
+  .chip--revealed {{ background: var(--missing-soft); color: var(--missing); border: 1px solid var(--missing); }}
+  @media (prefers-reduced-motion: no-preference) {{
+    .chip--revealed {{ animation: reveal 0.25s ease-out; }}
+    @keyframes reveal {{
+      from {{ opacity: 0; transform: translateY(-2px) scale(0.92); }}
+      to {{ opacity: 1; transform: none; }}
+    }}
+  }}
+
+  footer.legend {{
+    margin-top: 3rem; padding-top: 1.25rem; border-top: 1px solid var(--line);
+    font-size: 0.82rem; color: var(--ink-soft); max-width: 62ch;
+  }}
+  footer.legend p {{ margin: 0 0 0.6rem; }}
+
+  @media (max-width: 480px) {{
+    main {{ padding: 1.5rem 0.85rem 4rem; }}
+    .tree {{ padding-left: 1.15rem; }}
+    .tier-node::before {{ left: -1.5rem; width: 0.9rem; }}
+    .tier-node::after {{ left: -1.83rem; }}
+    .priority ol {{ columns: 1; }}
+  }}
+</style>
+
+<main>
+  <header class="page-head">
+    <p class="eyebrow">Lully · rapport de champs lexicaux</p>
+    <h1>Quels mots manquent encore au corpus ?</h1>
+    <p class="lede">
+      Pour chaque champ, une liste de mots-témoins caractéristiques du domaine est vérifiée
+      contre <code>lully/words.py</code>. Essaie de trouver les manquants toi-même — le bouton
+      « Révéler un indice » de chaque carte en sort un à la fois si tu sèches, prêt à copier
+      dans <code>addwords.py</code>. Ce rapport se régénère à chaque commit qui touche le corpus.
+    </p>
+    <div class="stats">
+      <div class="stat"><span class="n">{n_nouns}</span><span class="l">noms</span></div>
+      <div class="stat"><span class="n">{n_adj}</span><span class="l">adjectifs</span></div>
+      <div class="stat"><span class="n">{n_fields}</span><span class="l">champs suivis</span></div>
+    </div>
+    <div class="priority">
+      <h2>Par où commencer</h2>
+      <ol>{priority_html}</ol>
+    </div>
+  </header>
+
+  <div class="tree">{sections_html}
+  </div>
+
+  <footer class="legend">
+    <p><b>Méthode</b> — chaque champ est une liste-témoin de 8 à 30 mots caractéristiques,
+    vérifiée mot à mot (insensible à la casse) contre le corpus actuel. Un champ à 90 % n'a
+    pas forcément 90 % du vocabulaire français du domaine — seulement 90 % des mots-témoins
+    choisis. Les tiers (bien / partiellement / peu couverts) sont recalculés à chaque
+    génération, à partir de l'état courant du corpus.</p>
+    <p>{generated_line}</p>
+  </footer>
+</main>
+
+<script>
+  document.addEventListener("click", function (event) {{
+    var btn = event.target.closest(".reveal-btn");
+    if (!btn || btn.disabled) return;
+    var pool;
+    try {{
+      pool = JSON.parse(btn.dataset.pool || "[]");
+    }} catch (err) {{
+      pool = [];
+    }}
+    if (!pool.length) return;
+    var index = Math.floor(Math.random() * pool.length);
+    var word = pool.splice(index, 1)[0];
+    btn.dataset.pool = JSON.stringify(pool);
+    var chip = document.createElement("span");
+    chip.className = "chip chip--revealed";
+    chip.textContent = word;
+    btn.parentElement.querySelector(".reveal-chips").appendChild(chip);
+    if (pool.length > 0) {{
+      btn.textContent = "\\ud83d\\udd0d R\\u00e9v\\u00e9ler un indice (" + pool.length + " restant" + (pool.length > 1 ? "s" : "") + ")";
+    }} else {{
+      btn.textContent = "\\u2713 Tout est sorti";
+      btn.disabled = true;
+    }}
+  }});
+</script>
+"""
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--words", default="lully/words.py", help="path to words.py")
+    parser.add_argument("--out", default="docs/index.html", help="output HTML path")
+    args = parser.parse_args()
+
+    nouns, adjectives = load_words(args.words)
+
+    commit = os.environ.get("GITHUB_SHA", "")[:7]
+    source_label = f"automatiquement (commit {commit})" if commit else (
+        f"le {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')}"
+    )
+    html_out = build_html(nouns, adjectives, source_label)
+
+    out_dir = os.path.dirname(args.out)
+    if out_dir:
+        os.makedirs(out_dir, exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as f:
+        f.write(html_out)
+    print(f"wrote {args.out} ({len(nouns)} nouns, {len(adjectives)} adjectives, "
+          f"{len(FIELDS)} fields)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Made with Claude code.

Adds lexical_report.py, which checks lully/words.py against ~33 hand-picked semantic fields (rhetoric figures, sciences, emotions, anatomy, etc.) and reports, per field, which representative words are still missing from the corpus. Each field card shows a "Reveal a hint" button that pops one missing word at a time instead of dumping the full answer, so contributors can try to think of a word themselves first.

A GitHub Actions workflow regenerates docs/index.html on every push to main that touches lully/words.py or the script, and commits the result back. GitHub Pages still needs to be enabled manually (Settings > Pages
> Deploy from a branch > main /docs) to get a public URL.